### PR TITLE
Add complete local setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,38 @@ Creating a new kind of dating app. Or perhaps a new take on an old kind.
 
 ## Setup
 
+### Dependencies
+
 prerequisite: brew install opentofu (fork of terraform), docker, and yarn
 
-then run `yarn` to install dependencies. then `yarn dev` to start the server.
+then run `yarn` to install dependencies
+
+### Creating the Firebase project
+
+Sign up for [Firebase](https://console.firebase.google.com).
+
+Create a new project.
+
+Go to Project Settings > Service Account > Firebase Admin SDK
+
+Generate a new private key.
+
+Place the file somewhere on your computer. NOT IN THE REPO
+
+Install the [Firebase CLI](https://firebase.google.com/docs/cli).
+
+Select your project using the CLI:
+
+```sh
+firebase use --add
+# Select project ID
+# Set alias to `polylove`
+```
+
+Set the environment variable `GOOGLE_APPLICATION_CREDENTIALS_POLYLOVE` to the absolute path of your credential file.
+
+## Running
+
+Run `yarn dev` to start the server.
 
 See also [knowledge.md](knowledge.md), which is docs for AI coders.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Sign up for [Firebase](https://console.firebase.google.com).
 
 Create a new project.
 
+Enable Google Secret Manager in the [Google Cloud console](https://console.cloud.google.com/apis/api/secretmanager.googleapis.com/overview). You will need to activate billing on your project.
+
+Instal the [`gcloud` CLI](https://cloud.google.com/sdk/docs/install)
+
+Authenticate to Secret Manager using `gcloud`
+
 Go to Project Settings > Service Account > Firebase Admin SDK
 
 Generate a new private key.
@@ -32,7 +38,7 @@ firebase use --add
 # Set alias to `polylove`
 ```
 
-Set the environment variable `GOOGLE_APPLICATION_CREDENTIALS_POLYLOVE` to the absolute path of your credential file.
+Set the environment variable `GOOGLE_APPLICATION_CREDENTIALS_POLYLOVE` and `GOOGLE_APPLICATION_CREDENTIALS_DEV` to the absolute path of your credential file.
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Sign up for [Firebase](https://console.firebase.google.com).
 
 Create a new project.
 
+Add the Google authentication method in the Authentication section.
+
+Create a default bucket in the Storage section.
+
 Instal the [`gcloud` CLI](https://cloud.google.com/sdk/docs/install)
 
 Authenticate to Secret Manager using `gcloud`
@@ -44,11 +48,20 @@ Create a new project on [Supabase](https://supabase.com). Make sure to create th
 
 Export `SUPABASE_INSTANCE_ID` with the instance id displayed in your Supabase API settings.
 
+### Get a RapidAPI key for GeoDB
+
+Sign up to the basic plan on [RapidAPI](https://rapidapi.com/wirefreethought/api/geodb-cities/playground/apiendpoint_b648c05d-eef2-429f-a25a-1f3a743d8a3d) and create an API key. RapidAPI is used to access to the GeoDB API.
+
 ### Creating the secrets in Google Secret Manager
 
 Enable Google Secret Manager in the [Google Cloud console](https://console.cloud.google.com/apis/api/secretmanager.googleapis.com/overview). You will need to activate billing on your project.
 
-Create one secret for each key in common/src/secrets.ts. The important ones are the Supabase credentials which you can find in your Supabase API settings. You probably can put random values for the rest and let the features be broken.
+Create one secret for each key in common/src/secrets.ts.
+You can find the Supbase credentials in you Supabase API settings. Note that you should put the service_role/secret api key in SUPABASE_KEY, not the public key.
+
+The GeoDB one is the RapidAPI key you generated.
+
+You probably can put random values for the rest and let the features be broken.
 
 Run this command to get your service account email:
 
@@ -98,8 +111,16 @@ backend/supabase/user_events.sql
 backend/supabase/user_notifications.sql
 ```
 
+## Edit the client configuration
+
+Go on Firebase console and click on "Add a web app". Don't check the hosting checkbox.
+
+Then copy the Javascript config provided, and past it into `common/src/envs/dev.ts`, replacing the `firebaseConfig` key. Keep the `region` and `privateBucket` keys as is though.
+
+Update the `supabaseInstanceId` and `supabaseAnonKey` with the Supabase credentials in the Supabase API Settings.
+
 ## Running
 
-Run `yarn dev` to start the server.
+Run `./dev.sh dev` at the root of the project to start everything.
 
 See also [knowledge.md](knowledge.md), which is docs for AI coders.

--- a/README.md
+++ b/README.md
@@ -40,13 +40,15 @@ Set the environment variable `GOOGLE_APPLICATION_CREDENTIALS_POLYLOVE` and `GOOG
 
 ### Creating the Supabase DB
 
-Create a new project on [Supabase](https://supabase.com).
+Create a new project on [Supabase](https://supabase.com). Make sure to create the project in the **US West** region, as it's currently the hardcoded region in the connection code.
+
+Export `SUPABASE_INSTANCE_ID` with the instance id displayed in your Supabase API settings.
 
 ### Creating the secrets in Google Secret Manager
 
 Enable Google Secret Manager in the [Google Cloud console](https://console.cloud.google.com/apis/api/secretmanager.googleapis.com/overview). You will need to activate billing on your project.
 
-Create one secret for each key in common/src/secrets.ts. The important ones are the Supabase credentials which you can find in your [Supabase API setting](https://supabase.com/dashboard/project/eljzrcrvyxybkngvkcab/settings/api). You probably can put random values for the rest and let the features be broken.
+Create one secret for each key in common/src/secrets.ts. The important ones are the Supabase credentials which you can find in your Supabase API settings. You probably can put random values for the rest and let the features be broken.
 
 Run this command to get your service account email:
 
@@ -58,10 +60,42 @@ firebase-adminsdk  [SERVICE-ACCOUNT-EMAIL]  False
 ```
 
 Now run this command:
+
 ```sh
 gcloud projects add-iam-policy-binding FIREBASE-PROJECT-ID \
     --member="serviceAccount:SERVICE-ACCOUNT-EMAIL" \
     --role="roles/secretmanager.secretAccessor"
+```
+
+## Run the migrations
+
+Run the migrations using `psql`:
+
+```sh
+psql -h aws-0-us-west-1.pooler.supabase.com -p 6543 -d postgres -U postgres.SUPABASE-ID < MIGRATION_FILE
+```
+
+Run the migrations in this order:
+
+```
+backend/supabase/functions.sql
+backend/supabase/love_answers.sql
+backend/supabase/lovers.sql
+backend/supabase/lover_comments.sql
+backend/supabase/love_compatibility_answers.sql
+backend/supabase/love_likes.sql
+backend/supabase/love_questions.sql
+backend/supabase/love_ships.sql
+backend/supabase/love_stars.sql
+backend/supabase/love_waitlist.sql
+backend/supabase/private_users.sql
+backend/supabase/private_user_messages.sql
+backend/supabase/private_user_message_channels.sql
+backend/supabase/private_user_message_channel_members.sql
+backend/supabase/private_user_seen_message_channels.sql
+backend/supabase/users.sql
+backend/supabase/user_events.sql
+backend/supabase/user_notifications.sql
 ```
 
 ## Running

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ Sign up for [Firebase](https://console.firebase.google.com).
 
 Create a new project.
 
-Enable Google Secret Manager in the [Google Cloud console](https://console.cloud.google.com/apis/api/secretmanager.googleapis.com/overview). You will need to activate billing on your project.
-
 Instal the [`gcloud` CLI](https://cloud.google.com/sdk/docs/install)
 
 Authenticate to Secret Manager using `gcloud`
@@ -39,6 +37,32 @@ firebase use --add
 ```
 
 Set the environment variable `GOOGLE_APPLICATION_CREDENTIALS_POLYLOVE` and `GOOGLE_APPLICATION_CREDENTIALS_DEV` to the absolute path of your credential file.
+
+### Creating the Supabase DB
+
+Create a new project on [Supabase](https://supabase.com).
+
+### Creating the secrets in Google Secret Manager
+
+Enable Google Secret Manager in the [Google Cloud console](https://console.cloud.google.com/apis/api/secretmanager.googleapis.com/overview). You will need to activate billing on your project.
+
+Create one secret for each key in common/src/secrets.ts. The important ones are the Supabase credentials which you can find in your [Supabase API setting](https://supabase.com/dashboard/project/eljzrcrvyxybkngvkcab/settings/api). You probably can put random values for the rest and let the features be broken.
+
+Run this command to get your service account email:
+
+```sh
+> gcloud iam service-accounts list --project=FIREBASE-PROJECT-ID
+
+DISPLAY NAME       EMAIL                    DISABLED
+firebase-adminsdk  [SERVICE-ACCOUNT-EMAIL]  False
+```
+
+Now run this command:
+```sh
+gcloud projects add-iam-policy-binding FIREBASE-PROJECT-ID \
+    --member="serviceAccount:SERVICE-ACCOUNT-EMAIL" \
+    --role="roles/secretmanager.secretAccessor"
+```
 
 ## Running
 


### PR DESCRIPTION
Fixes #3 

For now, I added instructions to setup a firebase project. Still some way to go before `yarn dev` works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded setup instructions in the README.
  - Added comprehensive guides for configuring Firebase and Supabase, including dependency prerequisites and API key setup.
  - Detailed migration commands and improved client configuration guidance for easier project setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->